### PR TITLE
Add support for iPad 2 with 3G

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,2 +1,3 @@
 ENV{DEVTYPE}=="usb_device", ACTION=="add", BUS=="usb", SYSFS{idVendor}=="05ac", SYSFS{idProduct}=="129f", RUN+="/usr/bin/ipad_charge" 
 ENV{DEVTYPE}=="usb_device", ACTION=="add", BUS=="usb", SYSFS{idVendor}=="05ac", SYSFS{idProduct}=="129a", RUN+="/usr/bin/ipad_charge" 
+ENV{DEVTYPE}=="usb_device", ACTION=="add", BUS=="usb", SYSFS{idVendor}=="05ac", SYSFS{idProduct}=="12a2", RUN+="/usr/bin/ipad_charge"

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -9,9 +9,10 @@
 #define VERSION "1.1"
 
 #define CTRL_OUT	(LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT)
-#define VENDOR_APPLE	0x05ac
-#define PRODUCT_IPAD1	0x129a
-#define PRODUCT_IPAD2	0x129f
+#define VENDOR_APPLE		0x05ac
+#define PRODUCT_IPAD1		0x129a
+#define PRODUCT_IPAD2		0x129f
+#define PRODUCT_IPAD2_3G	0x12a2
 
 int set_charging_mode(libusb_device *dev, bool enable) {
 	int ret;
@@ -129,7 +130,7 @@ int main(int argc, char *argv[]) {
 				fprintf(stderr, "ipad_charge: failed to get device descriptor: error %d\n", ret);
 				continue;
 			}
-			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPAD1 || desc.idProduct == PRODUCT_IPAD2)) {
+			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPAD1 || desc.idProduct == PRODUCT_IPAD2 || desc.idProduct == PRODUCT_IPAD2_3G)) {
 				if (set_charging_mode(dev, enable) < 0)
 					fprintf(stderr, "ipad_charge: error setting charge mode\n");
 				else


### PR DESCRIPTION
My iPad 3G shows up as `ID 05ac:12a2 Apple, Inc.` in lsusb. Googe tells me that I'm not the only one with this device ID.

This little commit adds support for charging iPads with this device id.
