### PR TITLE
Add iPad2 3G Verizon version

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,6 +1,7 @@
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129f", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129a", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a2", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a3", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a4", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a6", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="1293", RUN+="/usr/bin/ipad_charge"

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -13,6 +13,7 @@
 #define PRODUCT_IPAD1		0x129a
 #define PRODUCT_IPAD2		0x129f
 #define PRODUCT_IPAD2_3G	0x12a2
+#define PRODUCT_IPAD2_3GV	0x12a3
 #define PRODUCT_IPAD3	    0x12a4
 #define PRODUCT_IPAD3_4G    0x12a6
 
@@ -143,6 +144,7 @@ int main(int argc, char *argv[]) {
 			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPAD1
 					|| desc.idProduct == PRODUCT_IPAD2
 					|| desc.idProduct == PRODUCT_IPAD2_3G
+					|| desc.idProduct == PRODUCT_IPAD2_3GV
 					|| desc.idProduct == PRODUCT_IPAD3
 					|| desc.idProduct == PRODUCT_IPAD3_4G
 					|| desc.idProduct == PRODUCT_IPOD_TOUCH_2G


### PR DESCRIPTION
The Verizon version of the iPad2 was missing.
