### PR TITLE
Support for iPad mini model 0x12ab

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,2 +1,2 @@
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9a]", RUN+="/usr/bin/ipad_charge"
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a[0-9a]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9ab]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a[0-9ab]", RUN+="/usr/bin/ipad_charge"


### PR DESCRIPTION
Hi, thanks for this great tool - been using it for some years now.
This little modification will add support for the iPad mini model 0x12ab the current rules only
works for models up to aa.
