### PR TITLE
Create ipad_charge_gui_frontend.tcl

### DIFF
--- a/ipad_charge_gui_frontend.tcl
+++ b/ipad_charge_gui_frontend.tcl
@@ -1,0 +1,50 @@
+#!/usr/bin/wish
+
+#Author: Rani Fayez Ahmad (Superlinux)
+#Date:22 July 2013
+#ranixlb@gmail.com
+#Interface/Frontend for ipad_charge
+wm title . {Linux Apple Device USB Charging}
+wm geometry . 500x100
+wm resizable . 0 0
+if { [ catch  { exec  lsusb -d 05ac:  } lsusb_outcome options ] }  {
+tk_messageBox -detail "NO Apple Device Found!\n Please plug in the device to charge the battery"
+exit
+} 
+
+set splits [ split $lsusb_outcome ]
+
+set busnum [ lindex $splits 1 ]
+set devnum [string trim [ lindex $splits 3 ] ":" ]
+
+set env_var "/usr/bin/env BUSNUM=$busnum DEVNUM=$devnum"
+
+proc turn_on_charging_mode {} {
+global env_var
+
+set cwd [pwd]
+set charger_command "exec $env_var $cwd/ipad_charge"
+if { [ catch  $charger_command  outcome options ] }  {
+tk_messageBox -detail " Please install ipad_charge and run this script in the same folder of ipad_charge \n $outcome"
+exit
+} 
+.status_label configure -text "Apple device USB charger is currently ON"
+}
+
+proc turn_off_charging_mode {} {
+global env_var
+set cwd [pwd]
+set charger_command "exec $env_var $cwd/ipad_charge -0"
+if { [ catch  $charger_command outcome options ] }  {
+tk_messageBox -detail " Please install ipad_charge and run this script in the same folder of ipad_charge\n $outcome "
+exit
+} 
+.status_label configure -text "Apple device USB charger is currently OFF"
+}
+
+button .turnoncharger -text {ON} -command turn_on_charging_mode
+button .turnoffcharger -text {OFF} -command turn_off_charging_mode
+label .status_label 
+place .turnoncharger -x 150 -y 20
+place  .turnoffcharger -x 250 -y 20
+place .status_label -x 10 -y 50


### PR DESCRIPTION
GUI Frontend for ipad_charge:
-------------
In the project/source code folder, the file ipad_charge_gui_frontend.tcl is a Tcl/Tk script. Therefore, you have to install
Tcl and Tk to be able to see a window with two buttons. One has [ON] (turns the USB charger ON),
and the other button has [OFF] (turns the USB charger OFF). Please watch the following 
YouTube video to know how to install Tcl and Tk:

http://www.youtube.com/watch?v=nGLeZuyhz88

After installing Tcl and Tk, don't forget to set the executable bit/permission on 
ipad_charge_gui_frontend.tcl using the command running from the same source code folder:

chmod +x ipad_charge_gui_frontend.tcl

to run from the same folder:
./ipad_charge_gui_frontend.tcl

You can can on Classical GNOME Desktop Environment do the same by:
1- Right click the file ipad_charge_gui_frontend.tcl and go to and click [Properties] .
2- Click [Permissions] and then click [Allow executing file as a program].
3- Press [OK] to save.
4- Double click the file ipad_charge_gui_frontend.tcl and then click [Run].
5- The frontend now should be displayed.