### PR TITLE
Patch for OpenWrt

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,1 +1,2 @@
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9a-f]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="remove", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9a-f]", RUN+="/usr/bin/ipad_charge --off"

--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,1 +1,1 @@
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9ab]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9a-f]", RUN+="/usr/bin/ipad_charge"

--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,2 +1,1 @@
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9ab]", RUN+="/usr/bin/ipad_charge"
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a[0-9ab]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12[9a][0-9ab]", RUN+="/usr/bin/ipad_charge"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra
+
 ipad_charge: ipad_charge.c
-	gcc -Wall -Wextra ipad_charge.c -lusb-1.0 -o ipad_charge
+	$(CC) $(CFLAGS) ipad_charge.c -lusb-1.0 -o ipad_charge
 
 install: ipad_charge
 	install -o root -g root -m 755 -s ipad_charge /usr/bin/

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -28,6 +28,10 @@
 #define PRODUCT_IPHONE_4S 0x12a0
 #define PRODUCT_IPHONE_5 0x12a8
 
+#define ERROR(fmt, ...)	do {	\
+	fprintf(stderr, "ipad_charge: %s#%d: " fmt, __func__, __LINE__, ## __VA_ARGS__); \
+} while (0)
+
 int set_charging_mode(libusb_device *dev, bool enable) {
 	int ret;
 	struct libusb_device_handle *dev_handle;

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -37,17 +37,17 @@ int set_charging_mode(libusb_device *dev, bool enable) {
 	struct libusb_device_handle *dev_handle;
 
 	if ((ret = libusb_open(dev, &dev_handle)) < 0) {
-		fprintf(stderr, "ipad_charge: unable to open device: error %d\n", ret);
+		ERROR("unable to open device: error %d\n", ret);
 		return ret;
 	}
 
 	if ((ret = libusb_claim_interface(dev_handle, 0)) < 0) {
-		fprintf(stderr, "ipad_charge: unable to claim interface: error %d\n", ret);
+		ERROR("unable to claim interface: error %d\n", ret);
 		goto out_close;
 	}
 
 	if ((ret = libusb_control_transfer(dev_handle, CTRL_OUT, 0x40, 0x6400, enable ? 0x6400 : 0, NULL, 0, 2000)) < 0) {
-		fprintf(stderr, "ipad_charge: unable to send command: error %d\n", ret);
+		ERROR("unable to send command: error %d\n", ret);
 		goto out_release;
 	}
 	
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
                         version();
                         exit(0);
                 default:
-                        fprintf(stderr, "Try '%s --help' for more information.\n", argv[0]);
+                        ERROR("Try '%s --help' for more information.\n", argv[0]);
                         exit(100);
                 }
         }
@@ -115,13 +115,13 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (libusb_init(NULL) < 0) {
-		fprintf(stderr, "ipad_charge: failed to initialise libusb\n");
+		ERROR("failed to initialise libusb\n");
 		exit(1);
 	}
 
 	libusb_device **devs;
 	if (libusb_get_device_list(NULL, &devs) < 0) {
-		fprintf(stderr, "ipad_charge: unable to enumerate USB devices\n");
+		ERROR("unable to enumerate USB devices\n");
 		ret = 2;
 		goto out_exit;
 	}
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
 			if (libusb_get_bus_number(dev) == busnum &&
 			    libusb_get_device_address(dev) == devnum) {
 			    	if (set_charging_mode(dev, enable) < 0)
-			    		fprintf(stderr, "ipad_charge: error setting charge mode\n");
+			    		ERROR("error setting charge mode\n");
 				else
 					count++;
 				break;
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
 		while ((dev = devs[i++]) != NULL) {
 			struct libusb_device_descriptor desc;
 			if ((ret = libusb_get_device_descriptor(dev, &desc)) < 0) {
-				fprintf(stderr, "ipad_charge: failed to get device descriptor: error %d\n", ret);
+				ERROR("failed to get device descriptor: error %d\n", ret);
 				continue;
 			}
 			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPAD1
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
 					|| desc.idProduct == PRODUCT_IPAD4)) {
 
 				if (set_charging_mode(dev, enable) < 0)
-					fprintf(stderr, "ipad_charge: error setting charge mode\n");
+					ERROR("error setting charge mode\n");
 				else
 					count++;
 			}
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (count < 1) {
-		fprintf(stderr, "ipad_charge: no such device or an error occured\n");
+		ERROR("no such device or an error occured\n");
 		ret = 3;
 	} else
 		ret = 0;

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -10,27 +10,41 @@
 
 #define CTRL_OUT	(LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT)
 #define VENDOR_APPLE		0x05ac
-#define PRODUCT_IPAD1		0x129a
-#define PRODUCT_IPAD2		0x129f
-#define PRODUCT_IPAD2_3G	0x12a2
-#define PRODUCT_IPAD2_4		0x12a9
-#define PRODUCT_IPAD2_3GV	0x12a3
-#define PRODUCT_IPAD3	    0x12a4
-#define PRODUCT_IPAD3_4G    0x12a6
-#define PRODUCT_IPAD4       0x12ab
+const uint16_t PRODUCT_APPLE[] = {
+	0x129a,		/* PRODUCT_IPAD1 */
+	0x129f,		/* PRODUCT_IPAD2 */
+	0x12a2,		/* PRODUCT_IPAD2_3G */
+	0x12a9,		/* PRODUCT_IPAD2_4 */
+	0x12a3,		/* PRODUCT_IPAD2_3GV */
+	0x12a4,		/* PRODUCT_IPAD3 */
+	0x12a6,		/* PRODUCT_IPAD3_4G */
+	0x12ab,		/* PRODUCT_IPAD4 */
 
-#define PRODUCT_IPOD_TOUCH_2G 0x1293
-#define PRODUCT_IPHONE_3GS 0x1294
-#define PRODUCT_IPHONE_4_GSM 0x1297
-#define PRODUCT_IPOD_TOUCH_3G 0x1299
-#define PRODUCT_IPHONE_4_CDMA 0x129c
-#define PRODUCT_IPOD_TOUCH_4G 0x129e
-#define PRODUCT_IPHONE_4S 0x12a0
-#define PRODUCT_IPHONE_5 0x12a8
+	0x1293,		/* PRODUCT_IPOD_TOUCH_2G */
+	0x1294,		/* PRODUCT_IPHONE_3GS */
+	0x1297,		/* PRODUCT_IPHONE_4_GSM */
+	0x1299,		/* PRODUCT_IPOD_TOUCH_3G */
+	0x129c,		/* PRODUCT_IPHONE_4_CDMA */
+	0x129e,		/* PRODUCT_IPOD_TOUCH_4G */
+	0x12a0,		/* PRODUCT_IPHONE_4S */
+	0x12a8,		/* PRODUCT_IPHONE_5 */
+};
 
 #define ERROR(fmt, ...)	do {	\
 	fprintf(stderr, "ipad_charge: %s#%d: " fmt, __func__, __LINE__, ## __VA_ARGS__); \
 } while (0)
+
+int is_apple_product(uint16_t productId) {
+	unsigned int i;
+
+	for (i = 0; i < sizeof(PRODUCT_APPLE)/sizeof(PRODUCT_APPLE[0]); i++) {
+		if (productId == PRODUCT_APPLE[i]) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
 
 int set_charging_mode(libusb_device *dev, bool enable) {
 	int ret;
@@ -148,23 +162,7 @@ int main(int argc, char *argv[]) {
 				ERROR("failed to get device descriptor: error %d\n", ret);
 				continue;
 			}
-			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPAD1
-					|| desc.idProduct == PRODUCT_IPAD2
-					|| desc.idProduct == PRODUCT_IPAD2_3G
-					|| desc.idProduct == PRODUCT_IPAD2_4
-					|| desc.idProduct == PRODUCT_IPAD2_3GV
-					|| desc.idProduct == PRODUCT_IPAD3
-					|| desc.idProduct == PRODUCT_IPAD3_4G
-					|| desc.idProduct == PRODUCT_IPOD_TOUCH_2G
-					|| desc.idProduct == PRODUCT_IPHONE_3GS
-					|| desc.idProduct == PRODUCT_IPHONE_4_GSM
-					|| desc.idProduct == PRODUCT_IPOD_TOUCH_3G
-					|| desc.idProduct == PRODUCT_IPHONE_4_CDMA
-					|| desc.idProduct == PRODUCT_IPOD_TOUCH_4G
-					|| desc.idProduct == PRODUCT_IPHONE_4S
-					|| desc.idProduct == PRODUCT_IPHONE_5
-					|| desc.idProduct == PRODUCT_IPAD4)) {
-
+			if (desc.idVendor == VENDOR_APPLE && is_apple_product(desc.idProduct)) {
 				if (set_charging_mode(dev, enable) < 0)
 					ERROR("error setting charge mode\n");
 				else


### PR DESCRIPTION
The following changes since commit 953f1e7a7078333d79c9c56a3d480fe5152698e2:

  Merge pull request #22 from Shirk/master (2013-02-17 04:51:28 -0800)

are available in the git repository at:

  https://github.com/yousong/ipad_charge.git patch-for-openwrt

Yousong Zhou (8):
      Patch Makefile to allow for cross-compilation.
      Add ERROR macro for debug message output.
      Replace fprintf with ERROR macro.
      Add function is_apple_product().
      Use SUBSYSTEM=usb to test if called by hotplug system.
      Merge udev rules into one.
      Modify regex in udev rule to match iPad2 and other devices.
      Add remove action rules for udev.

 95-ipad_charge.rules |    4 +-
 Makefile             |    5 ++-
 ipad_charge.c        |  119 ++++++++++++++++++++++++++------------------------
 3 files changed, 68 insertions(+), 60 deletions(-)
