### PR TITLE
Add missing ids 129c, 129e, 129f to udev rules.

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,2 +1,2 @@
-ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9ab]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9abcef]", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a[0-9ab]", RUN+="/usr/bin/ipad_charge"


### PR DESCRIPTION
Commit d4c239a simplified 95-ipad_charge.rules but now ignores usb ids
129[cef], which are present in ipad_charge.c.
