### PR TITLE
Add BlackBerry Q10 support, auto scan devices

### DIFF
--- a/95-ipad_charge.rules
+++ b/95-ipad_charge.rules
@@ -1,2 +1,3 @@
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="129[0-9abcef]", RUN+="/usr/bin/ipad_charge"
 ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="12a[0-9ab]", RUN+="/usr/bin/ipad_charge"
+ENV{DEVTYPE}=="usb_device", ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0fca", ATTR{idProduct}=="8014", RUN+="/usr/bin/ipad_charge"

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -6,18 +6,19 @@
 #include <unistd.h>
 #include <libusb-1.0/libusb.h>
 
-#define VERSION "1.1"
+#define VERSION "1.1.1"
 
 #define CTRL_OUT	(LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT)
-#define VENDOR_APPLE		0x05ac
-#define PRODUCT_IPAD1		0x129a
-#define PRODUCT_IPAD2		0x129f
-#define PRODUCT_IPAD2_3G	0x12a2
-#define PRODUCT_IPAD2_4		0x12a9
+#define VENDOR_APPLE 0x05ac
+#define PRODUCT_IPAD1	0x129a
+#define PRODUCT_IPAD2	0x129f
+#define PRODUCT_IPAD2_3G 0x12a2
+#define PRODUCT_IPAD2_4	0x12a9
 #define PRODUCT_IPAD2_3GV	0x12a3
-#define PRODUCT_IPAD3	    0x12a4
-#define PRODUCT_IPAD3_4G    0x12a6
-#define PRODUCT_IPAD4       0x12ab
+#define PRODUCT_IPAD3	0x12a4
+#define PRODUCT_IPAD3_4G 0x12a6
+#define PRODUCT_IPAD4_AIR_AIR2_MINI 0x12ab
+#define ADDITIONAL_VALUE_IPAD 1600
 
 #define PRODUCT_IPOD_TOUCH_2G 0x1293
 #define PRODUCT_IPHONE_3GS 0x1294
@@ -26,9 +27,17 @@
 #define PRODUCT_IPHONE_4_CDMA 0x129c
 #define PRODUCT_IPOD_TOUCH_4G 0x129e
 #define PRODUCT_IPHONE_4S 0x12a0
-#define PRODUCT_IPHONE_5 0x12a8
+#define PRODUCT_IPHONE_5_5S_6 0x12a8
+#define ADDITIONAL_VALUE_IPHONE 500
 
-int set_charging_mode(libusb_device *dev, bool enable) {
+#define VENDOR_RIM 0x0fca
+#define ADDITIONAL_VALUE_Q10 300
+#define PRODUCT_Q10 0x8014
+
+#define ADDITIONAL_VALUE_DEFAULT 1600
+
+
+int set_charging_mode(libusb_device *dev, bool enable, int additional_value) {
 	int ret;
 	struct libusb_device_handle *dev_handle;
 
@@ -46,11 +55,11 @@ int set_charging_mode(libusb_device *dev, bool enable) {
 	// Originally, the 4th was 0x6400, or 25600mA. I believe this was a bug and they meant 0x640, or 1600 mA which would be the max
 	// for the MFi spec. Also the typical values for the 3nd listed in the MFi spec are 0, 100, 500 so I chose 500 for that.
 	// And changed it to decimal to be clearer.
-	if ((ret = libusb_control_transfer(dev_handle, CTRL_OUT, 0x40, 500, enable ? 1600 : 0, NULL, 0, 2000)) < 0) {
+	if ((ret = libusb_control_transfer(dev_handle, CTRL_OUT, 0x40, 500, enable ? additional_value : 0, NULL, 0, 2000)) < 0) {
 		fprintf(stderr, "ipad_charge: unable to send command: error %d\n", ret);
 		goto out_release;
 	}
-	
+
 	ret = 0;
 
 out_release:
@@ -133,7 +142,7 @@ int main(int argc, char *argv[]) {
 		while ((dev = devs[i++]) != NULL) {
 			if (libusb_get_bus_number(dev) == busnum &&
 			    libusb_get_device_address(dev) == devnum) {
-			    	if (set_charging_mode(dev, enable) < 0)
+			    	if (set_charging_mode(dev, enable, ADDITIONAL_VALUE_DEFAULT) < 0)
 			    		fprintf(stderr, "ipad_charge: error setting charge mode\n");
 				else
 					count++;
@@ -155,21 +164,32 @@ int main(int argc, char *argv[]) {
 					|| desc.idProduct == PRODUCT_IPAD2_3GV
 					|| desc.idProduct == PRODUCT_IPAD3
 					|| desc.idProduct == PRODUCT_IPAD3_4G
-					|| desc.idProduct == PRODUCT_IPOD_TOUCH_2G
+          || desc.idProduct == PRODUCT_IPAD4_AIR_AIR2_MINI)) {
+				if (set_charging_mode(dev, enable, ADDITIONAL_VALUE_IPAD) < 0)
+					fprintf(stderr, "ipad_charge: error setting charge mode\n");
+				else
+					count++;
+			}
+			if (desc.idVendor == VENDOR_APPLE && (desc.idProduct == PRODUCT_IPOD_TOUCH_2G
 					|| desc.idProduct == PRODUCT_IPHONE_3GS
 					|| desc.idProduct == PRODUCT_IPHONE_4_GSM
 					|| desc.idProduct == PRODUCT_IPOD_TOUCH_3G
 					|| desc.idProduct == PRODUCT_IPHONE_4_CDMA
 					|| desc.idProduct == PRODUCT_IPOD_TOUCH_4G
 					|| desc.idProduct == PRODUCT_IPHONE_4S
-					|| desc.idProduct == PRODUCT_IPHONE_5
-					|| desc.idProduct == PRODUCT_IPAD4)) {
+					|| desc.idProduct == PRODUCT_IPHONE_5_5S_6)) {
 
-				if (set_charging_mode(dev, enable) < 0)
+				if (set_charging_mode(dev, enable, ADDITIONAL_VALUE_IPHONE) < 0)
 					fprintf(stderr, "ipad_charge: error setting charge mode\n");
 				else
 					count++;
 			}
+      if (desc.idVendor == VENDOR_RIM && desc.idProduct == PRODUCT_Q10) {
+				if (set_charging_mode(dev, enable, ADDITIONAL_VALUE_Q10) < 0)
+					fprintf(stderr, "ipad_charge: error setting charge mode\n");
+				else
+					count++;
+      }
 		}
 	}
 

--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -79,7 +79,7 @@ void help(char *progname) {
 	printf("  -V, --version\t\t\tdisplay version information and exit\n");
 	printf("\nExamples:\n");
 	printf("  ipad_charge\t\t\t\t\tenable charging on all connected iPads\n");
-	printf("  BUSNUM=004 DEVNUM=014 ipad_charge -off\tdisable charging on iPad connected on bus 4, device 14\n");
+	printf("  BUS=004 DEV=014 ipad_charge -off\tdisable charging on iPad connected on bus 4, device 14\n");
 }
 
 void version() {
@@ -118,9 +118,9 @@ int main(int argc, char *argv[]) {
                 }
         }
 
-	if (getenv("BUSNUM") && getenv("DEVNUM")) {
-		busnum = atoi(getenv("BUSNUM"));
-		devnum = atoi(getenv("DEVNUM"));
+	if (getenv("BUS") && getenv("DEV")) {
+		busnum = atoi(getenv("BUS"));
+		devnum = atoi(getenv("DEV"));
 	}
 
 	if (libusb_init(NULL) < 0) {
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
 
 	libusb_device *dev;
 	int i = 0, count = 0;
-	/* if BUSNUM and DEVNUM were specified (by udev), find device by address */
+	/* if BUSNUM and DEVNUM were specified by user, find device by address */
 	if (busnum && devnum) {
 		while ((dev = devs[i++]) != NULL) {
 			if (libusb_get_bus_number(dev) == busnum &&
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
 				break;
 			}
 		}
-	/* otherwise apply to all devices */
+	/* otherwise find and apply to all devices */
 	} else {
 		while ((dev = devs[i++]) != NULL) {
 			struct libusb_device_descriptor desc;
@@ -165,6 +165,7 @@ int main(int argc, char *argv[]) {
 					|| desc.idProduct == PRODUCT_IPAD3
 					|| desc.idProduct == PRODUCT_IPAD3_4G
           || desc.idProduct == PRODUCT_IPAD4_AIR_AIR2_MINI)) {
+
 				if (set_charging_mode(dev, enable, ADDITIONAL_VALUE_IPAD) < 0)
 					fprintf(stderr, "ipad_charge: error setting charge mode\n");
 				else


### PR DESCRIPTION
I think we should support more devices (Q10 in this commit). And we dont need to get BUSNUM and DEVNUM via udev, we will scan suitable device via vendor and product id.
* Add Q10 info to udev rule
* Add new ipad, iphone devices
* New rule (I think it is better): iphone (1000mAh), ipad (2100mAh), Q10 (800mAh), default (2100mAh)