### PR TITLE
Make utility work in the face of 2 issues found on Ubuntu 16.04

### DIFF
--- a/ipad_charge.c
+++ b/ipad_charge.c
@@ -38,20 +38,27 @@ int set_charging_mode(libusb_device *dev, bool enable) {
 		return ret;
 	}
 
-        // Resource Busy issue is caused because kernel is attached to device, so enable auto detach
-        if ((ret = libusb_set_auto_detach_kernel_driver(dev_handle, 1)) < 0) {
-                fprintf(stderr, "ipad_charge: set auto detach failed: error %d\n", ret);
-                fprintf(stderr, "ipad_charge: %s\n", libusb_strerror(ret));
-                return ret;
-        }
+	// Resource Busy issue is caused because kernel is attached to device, so enable auto detach
+	if ((ret = libusb_set_auto_detach_kernel_driver(dev_handle, 1)) < 0) {
+		fprintf(stderr, "ipad_charge: set auto detach failed: error %d\n", ret);
+		fprintf(stderr, "ipad_charge: %s\n", libusb_strerror(ret));
+		return ret;
+	}
 
-        // Original code assumes the bInterfaceNumber is always 0, for me it turned out to be 2.
-        // You can use lsusb to find out which interface numbers are available.
-        if ((ret = libusb_claim_interface(dev_handle, 2)) < 0) {
-                fprintf(stderr, "ipad_charge: unable to claim interface: error %d\n", ret);
-                fprintf(stderr, "ipad_charge: %s\n", libusb_strerror(ret));
-                goto out_close;
-        }
+	int bInterfaceNumber = 0;
+	// Original code assumes the bInterfaceNumber is always 0, for me it turned out to be 2.
+	// You can use lsusb to find out which interface numbers are available.
+	if ((ret = libusb_claim_interface(dev_handle, bInterfaceNumber)) < 0) {
+		fprintf(stderr, "ipad_charge: unable to claim interface 0: error %d\n", ret);
+		fprintf(stderr, "ipad_charge: %s\n", libusb_strerror(ret));
+		bInterfaceNumber = 2;
+		if ((ret = libusb_claim_interface(dev_handle, 2)) < 0) {
+			fprintf(stderr, "ipad_charge: unable to claim interface 2: error %d\n", ret);
+			fprintf(stderr, "ipad_charge: %s\n", libusb_strerror(ret));
+			goto out_close;
+		}
+	}
+
 
 	// the 3rd and 4th numbers are the extra current in mA that the Apple device may draw in suspend state.
 	// Originally, the 4th was 0x6400, or 25600mA. I believe this was a bug and they meant 0x640, or 1600 mA which would be the max
@@ -66,7 +73,7 @@ int set_charging_mode(libusb_device *dev, bool enable) {
 	ret = 0;
 
 out_release:
-	libusb_release_interface(dev_handle, 2);
+	libusb_release_interface(dev_handle, bInterfaceNumber);
 out_close:
 	libusb_close(dev_handle);
 


### PR DESCRIPTION
I hit 2 issues:
 1. Resource busy: need to set device to auto detach
 2. Interface number hardcoded to 0, but turned out to be 2
I also added some output to help future failures easier to diagnose (I think). Arguably those should be put behind a 'quiet' flag. While doing this I formatted the errors (for the better I believe).
This fixed issues #42 (for me) and perhaps issue #34